### PR TITLE
Docs tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ authconfig.json
 node_modules/
 dist/
 .env
+docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "newman": "^5.3.2",
         "prettier": "2.8.1",
         "ts-jest": "^29.0.3",
+        "typedoc": "^0.23.24",
         "typescript": "^4.9.4"
       }
     },
@@ -5330,6 +5331,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsprim": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
@@ -5433,6 +5440,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5462,6 +5475,18 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/media-typer": {
@@ -6661,6 +6686,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.12.1.tgz",
+      "integrity": "sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -7174,6 +7210,48 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.24",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.24.tgz",
+      "integrity": "sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.5",
+        "minimatch": "^5.1.2",
+        "shiki": "^0.12.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -7364,6 +7442,18 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node ./dist/src/index.js",
     "sanityTests": "newman run ./test/sanity/SanityTests.postman_collection.json",
     "test": "jest; npm run sanityTests",
-    "prettier": "npx prettier --write ."
+    "prettier": "npx prettier --write .",
+    "doc": "npx typedoc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "newman": "^5.3.2",
     "prettier": "2.8.1",
     "ts-jest": "^29.0.3",
+    "typedoc": "^0.23.24",
     "typescript": "^4.9.4"
   },
   "jest": {

--- a/src/services/parserContext.services.ts
+++ b/src/services/parserContext.services.ts
@@ -4,8 +4,13 @@ import { XMLParser } from 'fast-xml-parser';
 export { parse };
 
 /****************** PARSER CONTEXT PUBLIC FUNCTIONS **********************/
-//Parses one SBOM, query, returns list of Vulnerabilities
-function parse(sbom: any, strategy: SbomFormat): Package[] {
+/**
+ * Parse one SBOM, query, returns list of Vulnerabilities
+ * @param sbom a software bill of materials (SBOM)
+ * @param strategy the parsing strategy taken on sbom
+ * @returns  a list of packages contained in sbom
+ */
+function parse(sbom: string, strategy: SbomFormat): Package[] {
   //Set strategy
   let parser: ParsingStrategy = parsingStrategies[strategy];
   //Parse file
@@ -13,6 +18,13 @@ function parse(sbom: any, strategy: SbomFormat): Package[] {
 }
 
 /****************** PARSING STRATEGY INTERFACE **********************/
+/**
+ * A parsing strategy is the strategy taken to extract packages from
+ * a Software Bill of Materials (SBOM),
+ * dependant on SBOM format
+ *
+ * @interface ParsingStrategy
+ */
 interface ParsingStrategy {
   (sbom: string): Package[];
 }
@@ -23,7 +35,13 @@ let spdxTagValueParser: ParsingStrategy;
 let cyclonedxJsonParser: ParsingStrategy;
 let cyclonedxXmlParser: ParsingStrategy;
 
-//Cleaner implementaions
+/**
+ * Parsing Strategy implementation used to parse
+ * a Software Bill of Materials (SBOM)
+ * with SPDX specifications, in JSON format
+ * @param sbom the SBOM string
+ * @returns list of packages contained in sbom
+ */
 spdxJsonParser = function (sbom): Package[] {
   let packages: Package[] = [];
   let sbomPackages: any = JSON.parse(sbom).packages; //get all packages
@@ -58,6 +76,13 @@ spdxJsonParser = function (sbom): Package[] {
   return packages;
 };
 
+/**
+ * Parsing Strategy implementation used to parse
+ * a Software Bill of Materials (SBOM)
+ * with SPDX specifications, in TAG/VALUE format
+ * @param sbom the SBOM string
+ * @returns list of packages contained in sbom
+ */
 spdxTagValueParser = function (sbom): Package[] {
   let packages: Package[] = [];
   let sbomArray = sbom.toString().split(/\n[#]+.*(?:Package).*\n/gm); //split string by packages
@@ -114,7 +139,6 @@ spdxTagValueParser = function (sbom): Package[] {
   return packages;
 };
 
-/* Create a list of Packages from JSON package list in CycloneDX format */
 function cyclonedxGetPackages(sbomPackages: any): Package[] {
   let packages: Package[] = [];
   sbomPackages.forEach(function (pkg: any) {
@@ -141,6 +165,13 @@ function cyclonedxGetPackages(sbomPackages: any): Package[] {
   return packages;
 }
 
+/**
+ * Parsing Strategy implementation used to parse
+ * a Software Bill of Materials (SBOM)
+ * with CYCLONEDX specifications, in XML format
+ * @param sbom the SBOM string
+ * @returns list of packages contained in sbom
+ */
 cyclonedxXmlParser = function (sbom): Package[] {
   //Convert xml --> json
   const parser = new XMLParser({
@@ -153,6 +184,13 @@ cyclonedxXmlParser = function (sbom): Package[] {
   return cyclonedxGetPackages(sbomPackages);
 };
 
+/**
+ * Parsing Strategy implementation used to parse
+ * a Software Bill of Materials (SBOM)
+ * with CYCLONEDX specifications, in JSON format
+ * @param sbom the SBOM string
+ * @returns list of packages contained in sbom
+ */
 cyclonedxJsonParser = function (sbom): Package[] {
   //Trim sbom to only package list
   let sbomPackages: any = JSON.parse(sbom).components;

--- a/src/utils/queryFacade.utils.ts
+++ b/src/utils/queryFacade.utils.ts
@@ -2,8 +2,25 @@ import { Query, VulDatabase } from '@utils/types.utils';
 import { Vulnerability } from '@utils/types.utils';
 import axios from 'axios';
 
+/****************** QUERY FACADE API **********************/
+/**
+ * Search an external vulnerability database
+ * @param query specifying vulnerability database and search method
+ * @returns a list of vulnerabilities found in database
+ */
+async function sendQuery(query: Query) {
+  return getVulnerabilities(query).then((response) => {
+    //Handle error
+    if (!isNaN(response)) {
+      //To-do error handleide
+      return [];
+    }
+    return cleaningStrategy[query.database](response);
+  });
+}
+
 /***************** GET VULNERABILITIES FROM EXT DATABASES ****************************/
-export async function getVulnerabilities(query: Query) {
+async function getVulnerabilities(query: Query) {
   let config: any = {
     method: query.method,
     url: query.database,
@@ -119,19 +136,6 @@ let cleaningStrategy = {
   [VulDatabase.SONATYPE]: sonatypeCleaner,
   [VulDatabase.NVD]: nvdCleaner,
 };
-
-/****************** QUERY FACADE API **********************/
-//Sends one query, returns list of Vulnerabilities
-async function sendQuery(query: Query) {
-  return getVulnerabilities(query).then((response) => {
-    //Handle error
-    if (!isNaN(response)) {
-      //To-do error handleide
-      return [];
-    }
-    return cleaningStrategy[query.database](response);
-  });
-}
 
 /** Module Exports */
 export { sendQuery };

--- a/src/utils/types.utils.ts
+++ b/src/utils/types.utils.ts
@@ -1,9 +1,15 @@
+/**
+ * @enum Represents URLs of supported vulnerability databases
+ */
 export enum VulDatabase {
   NVD = 'https://services.nvd.nist.gov/rest/json/cves/2.0',
   SONATYPE = 'https://ossindex.SONATYPE.org/api/v3/authorized/component-report',
   /*Add supported DBs here */
 }
 
+/**
+ * @enum Supported SBOM formats
+ */
 export enum SbomFormat {
   SPDX_JSON,
   SPDX_TAGVALUE,
@@ -12,6 +18,9 @@ export enum SbomFormat {
   /*Add supported sbom formats here */
 }
 
+/**
+ * Generic query type used to config vulnerability search to external databases
+ */
 export interface Query {
   database: VulDatabase;
   method: string;
@@ -20,6 +29,9 @@ export interface Query {
   body: any | null;
 }
 
+/**
+ * Represents a software package
+ */
 export interface Package {
   id: string;
   name: string;
@@ -32,6 +44,9 @@ export interface Package {
   version: string | undefined;
 }
 
+/**
+ * Represents a cve vulnerability
+ */
 export interface Vulnerability {
   cveId: string;
   packgaeId: number;

--- a/test/unit/parserContext.test.ts
+++ b/test/unit/parserContext.test.ts
@@ -25,7 +25,8 @@ const cyclonedx_json = fs.readFileSync(
   'utf-8'
 );
 const cyclonedx_xml = fs.readFileSync(
-  path.join(getAppRootDir(), sbom_filepath, 'bom.cyclonedx.xml')
+  path.join(getAppRootDir(), sbom_filepath, 'bom.cyclonedx.xml'),
+  'utf-8'
 );
 
 //SPDX JSON

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src"],
+  "out": "docs",
+  "entryPointStrategy": "expand"
+}


### PR DESCRIPTION
Adds documentation tools to the project.
Uses typedoc.
Documentation is generated in /docs and can be run with `$npm run doc`

**Configure docs**
I used one default config from typedoc but anyone feel free to change the display configuration
Files: `package.json` , `typedoc.json`

**Document existing code**
I documented the exported modules of each existing feature in main.
Parser, QueryFacade and types.utils
