### PR TITLE
Enable front end Integration by enabling CORS 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@types/express-fileupload": "^1.4.1",
-        "axios": "^1.2.1"
+        "axios": "^1.2.1",
+        "cors": "^2.8.5"
       },
       "devDependencies": {
         "@babel/core": "^7.20.5",
@@ -3680,6 +3681,18 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -6146,6 +6159,14 @@
         "node": "*"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-hash": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
@@ -7973,7 +7994,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/z-arnott/Vega#readme",
   "dependencies": {
     "@types/express-fileupload": "^1.4.1",
-    "axios": "^1.2.1"
+    "axios": "^1.2.1",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import fileUpload from 'express-fileupload';
 
 const express = require('express');
 const app = express();
+var cors = require('cors');
+app.use(cors());
 app.use(express.json());
 app.use(fileUpload());
 const port = 8088; // default port to listen


### PR DESCRIPTION
**Enabled front end Integration by enabling CORS**

It's a super short change, but TLDR it enables requests from other domains to access the our server. 

Even though the front end and back end are both on local host we need to enable this for requests to go across. If not they get rejected due to a network error. For more information see here: 
https://stackoverflow.com/questions/45980173/react-axios-network-error