### PR TITLE
fix analysis time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,9 @@ app.post('/upload', (req: any, res: any, next: any) => {
 
 app.get('/riskanalysis', (req: any, res: any, next: any) => {
   let sessionId = req.query.sessionId;
-  analyzeSystem(sessionId).then((risk) => {
-    console.log('System Risk ' + risk);
+  analyzeSystem(sessionId).then( () => {
+    res.send('Analysis complete');
   });
-  res.send('Analysis in progress');
 });
 
 app.get('/dashboard', (req: any, res: any, next: any) => {

--- a/src/services/riskAnalysis.services.ts
+++ b/src/services/riskAnalysis.services.ts
@@ -3,7 +3,7 @@ import { logger } from '../utils/logger.utils';
 import {
   readAllPackages,
   readVulnsByPkg,
-  writePackage,
+  updatePackage,
   writeVuln,
 } from '../utils/storageFacade.utils';
 
@@ -18,7 +18,6 @@ const maxLikelihood = 1;
  */
 export async function analyzeSystem(sessionId: number) {
   let packages = await readAllPackages(sessionId);
-  let highest = 0;
   //Package Level
   for (let p of packages) {
     let cves = await readVulnsByPkg(p.ref, sessionId);
@@ -35,15 +34,8 @@ export async function analyzeSystem(sessionId: number) {
         '\nCVEs Analyzed:\n' +
         JSON.stringify(cves, null, 2)
     );
-    //System Risk
-    if (p.highestRisk == null) {
-      logger.warn('System Risk Analysis: ' + p.ref + ' risk undefined');
-    } else {
-      highest = Math.max(highest, p.highestRisk);
-    }
-    await writePackage(p, sessionId);
+    updatePackage(p, sessionId);
   }
-  return highest;
 }
 /**
  * Find the consolodated risk and highest risk of a package based on the package's vulnerabilities

--- a/src/utils/storageFacade.utils.ts
+++ b/src/utils/storageFacade.utils.ts
@@ -424,7 +424,7 @@ async function insertPackage(pkg: Package, sessionId: number) {
   return status;
 }
 
-async function updatePackage(pkg: Package, sessionId: number) {
+export async function updatePackage(pkg: Package, sessionId: number) {
   let { status, error } = await supabase
     .from('packages')
     .update({


### PR DESCRIPTION
Analysis for >1k packages is very slow.
Fixed by removing `await` in analysis for-loop.
This allows multiple packages to be analyzed concurently